### PR TITLE
docs update: add sqlfmt vs code integration info

### DIFF
--- a/docs/integrations/vs-code.md
+++ b/docs/integrations/vs-code.md
@@ -1,5 +1,9 @@
 # VS Code
 
+:::info
+sqlfmt must be installed globally to integrate with VS Code
+:::
+
 There are several ways to integrate sqlfmt with VS Code. All require installation of an Extension from the VS Code Marketplace.
 
 If you already use [dbt Power User](./dbt-power-user.md) or [Trunk](./trunk.md), their extensions can configure sqlfmt as the default formatter and enable a run-on-save hook.


### PR DESCRIPTION
I was struggling to get sqlfmt integrated with VS Code using a venv environment so I started searching.  Here is the issue I came across.

https://github.com/innoverio/vscode-dbt-power-user/issues/234

Once I installed sqlfmt globally I was able to integrate sqlfmt with VS Code.  I propose adding an info block at the top until virtual environments can be used with the VS Code integration.