### PR TITLE
Update installation.mdx (fix poetry sqlfmt statement)

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -86,7 +86,7 @@ pipenv install -d shandy-sqlfmt
 With the [jinjafmt extra](./formatting-jinja.md) (recommended):
 
 ```bash
-pip install shandy-sqlfmt[jinjafmt]
+pip install 'shandy-sqlfmt[jinjafmt]'
 ```
 
 Without the jinjafmt extra:


### PR DESCRIPTION
Quotes are missing from the `poetry add -D shandy-sqlfmt[jinjafmt]` statement