### PR TITLE
Add additional SQLFluff exclude rules

### DIFF
--- a/docs/integrations/sqlfluff.md
+++ b/docs/integrations/sqlfluff.md
@@ -4,7 +4,7 @@ You can (and should!) use SQLFluff to lint your SQL queries after they are forma
 
 ```ini title=.sqlfluff
 [sqlfluff]
-exclude_rules = layout.indent, layout.cte_bracket, layout.select_targets, layout.spacing
+exclude_rules = layout.indent, layout.cte_bracket, layout.cte_newline, layout.select_targets, layout.spacing
 # set max_line_length to whatever you set in sqlfmt
 max_line_length = 88
 

--- a/docs/integrations/sqlfluff.md
+++ b/docs/integrations/sqlfluff.md
@@ -4,7 +4,7 @@ You can (and should!) use SQLFluff to lint your SQL queries after they are forma
 
 ```ini title=.sqlfluff
 [sqlfluff]
-exclude_rules = layout.indent, layout.cte_bracket, layout.cte_newline, layout.select_targets, layout.spacing
+exclude_rules = layout.indent, layout.cte_bracket, layout.keyword_newline, layout.cte_newline, layout.select_targets, layout.spacing
 # set max_line_length to whatever you set in sqlfmt
 max_line_length = 88
 


### PR DESCRIPTION
Not exactly sure when `layout.cte_newline` ([LT08](https://docs.sqlfluff.com/en/stable/reference/rules.html#rule-LT08)) was introduced in SQLFluff, but it definitely conflicts with sqlfmt's opinions.

```sql
with
    a as (select 1 as a),
    
    b as (select * from a)

select * from b
```

Will be reformatted as:
```sql
with a as (select 1 as a), b as (select * from a) select * from b
```