### PR TITLE
docs: update changed-files version to latest version

### DIFF
--- a/docs/integrations/github-actions.md
+++ b/docs/integrations/github-actions.md
@@ -67,7 +67,7 @@ jobs:
         run: pip install shandy-sqlfmt[jinjafmt]
       - name: Get Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@v34
+        uses: tj-actions/changed-files@v46
       - name: Run sqlfmt
         run: sqlfmt --diff ${{ steps.changed-files.outputs.all_changed_files }}
 ```
@@ -121,7 +121,7 @@ jobs:
         run: pip install shandy-sqlfmt[jinjafmt]
       - name: Get Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@v34
+        uses: tj-actions/changed-files@v46
       - name: Run sqlfmt
         run: sqlfmt ${{ steps.changed-files.outputs.all_changed_files }}
       - name: Commit sqlfmt changes


### PR DESCRIPTION
We copied the example and the GH action failed until we updated the version of the changed-files plugin and figured we'd contribute the update to the docs as well. 